### PR TITLE
Add license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 global-exclude test.py
+include LICENSE.txt


### PR DESCRIPTION
Ensure that the license file is part of the source tarball that is published on PyPI.