### PR TITLE
Add support for OmniHub

### DIFF
--- a/omnilogic/__init__.py
+++ b/omnilogic/__init__.py
@@ -1020,14 +1020,19 @@ class OmniLogic:
                 site_telem["Unit-of-Measurement"] = config_item["System"]["Units"]
                 site_telem["Alarms"] = site_alarms
 
-                if type(config_item["Backyard"]["Sensor"]) == dict:
-                  site_telem["Unit-of-Temperature"] = config_item["Backyard"]["Sensor"][
-                      "Units"
-                  ]
-                else:
-                  for sensor in config_item["Backyard"]["Sensor"]:
-                    if sensor["Name"] == "AirSensor":
-                      site_telem["Unit-of-Temperature"] = sensor["Units"]
+                if "Sensor" in config_item["Backyard"]:
+                    if type(config_item["Backyard"]["Sensor"]) == dict:
+                      site_telem["Unit-of-Temperature"] = config_item["Backyard"]["Sensor"][
+                          "Units"
+                      ]
+                    else:
+                      for sensor in config_item["Backyard"]["Sensor"]:
+                        if sensor["Name"] == "AirSensor":
+                          site_telem["Unit-of-Temperature"] = sensor["Units"]
+                else: 
+                    site_telem["Unit-of-Temperature"] = config_item["Backyard"]["Body-of-water"]["Sensor"][
+                          "Units"
+                      ]
 
                 telem_list.append(site_telem)
 

--- a/omnilogic/__init__.py
+++ b/omnilogic/__init__.py
@@ -1021,18 +1021,25 @@ class OmniLogic:
                 site_telem["Alarms"] = site_alarms
 
                 if "Sensor" in config_item["Backyard"]:
-                    if type(config_item["Backyard"]["Sensor"]) == dict:
-                      site_telem["Unit-of-Temperature"] = config_item["Backyard"]["Sensor"][
-                          "Units"
-                      ]
-                    else:
-                      for sensor in config_item["Backyard"]["Sensor"]:
+                    sensors = config_item["Backyard"]["Sensor"]
+                else:
+                    sensors = config_item["Backyard"]["Body-of-water"]["Sensor"]
+                
+                hasAirSensor = False
+                
+                if type(sensors) == dict:
+                    site_telem["Unit-of-Temperature"] = sensors["Units"]
+                    
+                    if sensors["Name"] == "AirSensor":
+                        hasAirSensor = True
+                else:
+                    for sensor in sensors:
                         if sensor["Name"] == "AirSensor":
-                          site_telem["Unit-of-Temperature"] = sensor["Units"]
-                else: 
-                    site_telem["Unit-of-Temperature"] = config_item["Backyard"]["Body-of-water"]["Sensor"][
-                          "Units"
-                      ]
+                            site_telem["Unit-of-Temperature"] = sensor["Units"]
+                            hasAirSensor = True
+                            
+                if hasAirSensor == False:
+                    del site_telem["airTemp"]
 
                 telem_list.append(site_telem)
 


### PR DESCRIPTION
Hi, this change is to add support for the OmniHub systems.

These systems do not have any sensor right inside the "backyard" node so an exception is thrown when trying to figure out the unite-of-temperature. But there is a sensor inside the sub-node "body-of-water" so I added a little bit of logic to get it from there...

Tested and now the integration works beautifully in my Home Assistant setup.